### PR TITLE
Fix false positive matches with unsafe ports on SQD-3624

### DIFF
--- a/include/tests_squid
+++ b/include/tests_squid
@@ -249,7 +249,7 @@
             ReportSuggestion ${TEST_NO} "Check if Squid has been configured to restrict access to all safe ports"
           else
             logtext "Result: checking ACL safe ports"
-            FIND2=`grep "^acl Safe_ports port" ${SQUID_DAEMON_CONFIG} | awk '{ print $4 }'`
+            FIND2=`grep -w "^acl Safe_ports port" ${SQUID_DAEMON_CONFIG} | awk '{ print $4 }'`
             if [ "${FIND2}" = "" ]; then
                 Display --indent 6 --text "- Checking ACL 'Safe_ports' ports" --result "NONE FOUND" --color YELLOW
                 ReportSuggestion ${TEST_NO} "Check if Squid has been configured for which ports it can allow outgoing traffic (Safe_ports)"


### PR DESCRIPTION
In relation to this report:

https://github.com/CISOfy/lynis/issues/52

This should resolve issues with port numbers that contain a value in `SQUID_DAEMON_UNSAFE_PORTS_LIST` but aren't actually a match.
